### PR TITLE
Remove extra paren from auto-save settings section

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the following code to your `init.el` file to store these files in the
 var directory:
 
     (setq auto-save-file-name-transforms
-          `((".*" ,(no-littering-expand-var-file-name "auto-save/") t))))
+          `((".*" ,(no-littering-expand-var-file-name "auto-save/") t)))
 
 Conventions
 -----------


### PR DESCRIPTION
There appeared to be an extra paren, which may cause errors for serial copy pasters like me. 