### PR TITLE
Auto package update: Theme last update day file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -245,6 +245,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq ac-comphist-file                 (var "ac-comphist.el"))
     (setq anaconda-mode-installation-directory (etc "anaconda-mode/"))
     (setq async-byte-compile-log-file      (var "async-bytecomp.log"))
+    (setq apu--last-update-day-path        (var "auto-package-update-last-update-day"))
     (eval-after-load 'bbdb
       `(make-directory ,(var "bbdb/") t))
     (setq bbdb-file                        (var "bbdb/bbdb.el"))


### PR DESCRIPTION
Theme `apu--last-update-day-path'.
This file is used to store raw text and is the only data file of the package.

[Auto Package Update repo](https://github.com/rranelli/auto-package-update.el)