### PR TITLE
litable: theme litable-list-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -296,6 +296,7 @@ directories."
       `(make-directory ,(var "jabber/history/") t))
     (eval-after-load 'lookup
       `(make-directory ,(etc "lookup/") t))
+    (setq litable-list-file                (var "litable-list.el"))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq magithub-dir                     (var "magithub/"))
     (setq magithub-cache-file              (var "magithub/cache.el"))


### PR DESCRIPTION
- This file keeps track of which functions (beyond the defaults) you trust to be pure.
- This file is used to store an s-expression
- This is the only configuration/data file of the package
