### PR TITLE
elbank: re-theme elbank-data-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -260,7 +260,7 @@ This variable has to be set before `no-littering' is loaded.")
     (eval-after-load 'company-statistics
       `(make-directory ,(var "company/") t))
     (setq company-statistics-file          (var "company/statistics.el"))
-    (setq elbank-data-file                 (var "elbank-data.json"))
+    (setq elbank-data-file                 (var "elbank-data.el"))
     (eval-after-load 'elfeed
       `(make-directory ,(var "elfeed/") t))
     (setq elfeed-db-directory              (var "elfeed/db/"))


### PR DESCRIPTION
elbank switched from json to emacs lisp file format (in [#4a0905d4](https://gitlab.petton.fr/nico/elbank/commit/4a0905d4cb28f746ad6e012acf9f0d28d525ff09)).