### PR TITLE
pyim: theme `pyim-directory' and `pyim-dcache-directory'

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -324,6 +324,7 @@ directories."
       `(make-directory ,(var "projectile/") t))
     (setq projectile-cache-file            (var "projectile/cache.el"))
     (setq projectile-known-projects-file   (var "projectile/known-projects.el"))
+    (setq pyim-dcache-directory            (var "pyim/dcache/"))
     (setq quack-dir                        (var "quack/"))
     (setq request-storage-directory        (var "request/storage/"))
     (setq rmh-elfeed-org-files             (list (var "elfeed/rmh-elfeed.org")))


### PR DESCRIPTION
pyim is a Pinyin input method.

- `pyim-directory' is used to store related files.
- `pyim-dcache-directory' will store dictionary cache.

See also: https://github.com/tumashu/pyim