### PR TITLE
meghanada: theme `meghanada-server-install-dir'

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -307,6 +307,7 @@ directories."
     (setq magithub-dir                     (var "magithub/"))
     (setq magithub-cache-file              (var "magithub/cache.el"))
     (setq mc/list-file                     (var "mc-list.el"))
+    (setq meghanada-server-install-dir     (var "meghanada/"))
     (setq multi-compile-history-file       (var "multi-compile-history.el"))
     ;; The value of this variable MUST NOT end with ".el" but the
     ;; actual file name MUST end with ".el".  Use "git blame" for


### PR DESCRIPTION
meghanada is a Java completion engine.

This is the directory to store the meghanada server which will be conneced when
enable meghanada mode. When call `meghanada-update-server', it will download it
from 'dl.bintray.com'.

See also: https://github.com/mopemope/meghanada-emacs/blob/98ad6a5361c725319a355522d2d1ba0e0fbb7cde/meghanada.el#L107

Happy new year!