### PR TITLE
yasnippet: remove obsolete yas-installed-snippets-dir

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -349,8 +349,7 @@ directories."
     (setq xkcd-cache-dir                   (var "xkcd/"))
     (eval-after-load 'yasnippet
       `(make-directory ,(etc "yasnippet/snippets/") t))
-    (setq yas-snippet-dirs                 (list (etc "yasnippet/snippets/")
-                                                 'yas-installed-snippets-dir))
+    (setq yas-snippet-dirs                 (list (etc "yasnippet/snippets/")))
     ))
 
 (provide 'no-littering)


### PR DESCRIPTION
This variable was made obsolete and using it issues a warning when loading yasnippet now 

https://github.com/joaotavora/yasnippet/commit/b1ca2197062340d4c9e78442ea38957a96f968d4