### PR TITLE
window-purpose: theme variables

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -328,6 +328,8 @@ directories."
       `(make-directory ,(var "projectile/") t))
     (setq projectile-cache-file            (var "projectile/cache.el"))
     (setq projectile-known-projects-file   (var "projectile/known-projects.el"))
+    (setq purpose-default-layout-file      (etc "window-purpose/default-layout.el"))
+    (setq purpose-layout-dirs              (list (etc "window-purpose/layouts/")))
     (setq pyim-dcache-directory            (var "pyim/dcache/"))
     (setq quack-dir                        (var "quack/"))
     (setq request-storage-directory        (var "request/storage/"))


### PR DESCRIPTION
Theme `purpose-default-layout-file` and `purpose-layout-dirs`.

purpose-default-layout-file:
- This file is used to store an s-expression.

purpose-layout-dirs:
- Files stored here are also used for s-expressions, but the package does not allow changing the
  file name extensions.

Upstream: https://github.com/bmag/emacs-purpose
