### PR TITLE
auto-package-update: theme `apu--last-update-day-filename`

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -250,6 +250,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq ac-comphist-file                 (var "ac-comphist.el"))
     (setq amx-save-file                    (var "amx-save.el"))
     (setq anaconda-mode-installation-directory (var "anaconda-mode/"))
+    (setq apu--last-update-day-filename    (var "auto-update-package-last-update-day")
     (setq async-byte-compile-log-file      (var "async-bytecomp.log"))
     (eval-after-load 'bbdb
       `(make-directory ,(var "bbdb/") t))


### PR DESCRIPTION
This file is used to store raw text.
This is the only configuration/data file of the package.
Its default value is `.last-package-update-day`.

https://github.com/rranelli/auto-package-update.el