### PR TITLE
pandoc-mode: theme `pandoc-data-dir'

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -322,6 +322,7 @@ directories."
       `(make-directory ,(var "org/caldav/save") t))
     (setq org-caldav-backup-file           (var "org/caldav/backup.org"))
     (setq org-caldav-save-directory        (var "org/caldav/save"))
+    (setq pandoc-data-dir                  (etc "pandoc-mode/"))
     (setq pcache-directory                 (var "pcache/"))
     (setq persistent-scratch-save-file     (var "persistent-scratch.el"))
     (setq persp-save-dir                   (var "persp-mode/"))


### PR DESCRIPTION
pandoc-mode repository: https://github.com/joostkremers/pandoc-mode

The `pandoc-data-dir` directory really contains config, not data, even though the variable is named `pandoc-data-dir`. The config files contain S-expressions describing the desired options for pandoc output formats.
