### PR TITLE
auto-package-update: theme variables

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -251,6 +251,8 @@ This variable has to be set before `no-littering' is loaded.")
     (setq amx-save-file                    (var "amx-save.el"))
     (setq anaconda-mode-installation-directory (var "anaconda-mode/"))
     (setq async-byte-compile-log-file      (var "async-bytecomp.log"))
+    (setq apu--last-update-day-filename    (var "auto-package-update-last-update-day"))
+    (setq apu--last-update-day-path        (var "auto-package-update-last-update-day"))
     (eval-after-load 'bbdb
       `(make-directory ,(var "bbdb/") t))
     (setq bbdb-file                        (var "bbdb/bbdb.el"))


### PR DESCRIPTION
Repository for `auto-package-update`: https://github.com/rranelli/auto-package-update.el

Theme:

- `apu--last-update-day-filename`
- `apu--last-update-day-path`

The variable ending in `-path` actually also points to the file. This file contains the timestamp of the last automatic package update.

Without this `no-littering` rule, `auto-package-update` will put this file in `~/.emacs.d/.last-package-update-day`.