### PR TITLE
emms: Automatically create emms folder for emms-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -277,6 +277,8 @@ This variable has to be set before `no-littering' is loaded.")
 This function overrides the one on `x-win' to use `no-littering'
 directories."
              (expand-file-name session-id ,session-dir)))))
+    (eval-after-load 'emms
+      `(make-directory ,(var "emms/") t))
     (setq emms-directory                   (var "emms/"))
     (eval-after-load 'emojify
       `(make-directory ,(var "emojify/") t))


### PR DESCRIPTION
Emms does *not* create automatically the folder for `emms-directory`.

I see popular package like `helm` and `elfeed` have
also `make-directory` functions in `no-littering` which makes me
think it is ok.

But then this confuses me a bit:

   - This package does/doesn't take care of creating the containing
     directory if necessary. (If the package does not do it, then you
     should also fix that and submit an upstream pull request.)


Should I fix this upstream?
If so, you can close this PR and I'll submit a patch to emms instead.

Thanks.
