### PR TITLE
dired-recent: theme dired-recent-directories-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -263,6 +263,7 @@ This variable has to be set before `no-littering' is loaded.")
     (eval-after-load 'company-statistics
       `(make-directory ,(var "company/") t))
     (setq company-statistics-file          (var "company/statistics.el"))
+    (setq dired-recent-directories-file    (var "dired-recent-directories.el"))
     (setq elbank-data-file                 (var "elbank-data.el"))
     (eval-after-load 'elfeed
       `(make-directory ,(var "elfeed/") t))


### PR DESCRIPTION
[dired-recent](https://github.com/vifon/dired-recent.el) keeps a history of paths visited with Dired.

`dired-recent-directories-file` contains the above mentioned paths.