### PR TITLE
treemacs: theme treemacs-persist-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -347,6 +347,7 @@ directories."
       `(make-directory ,(var "sx/cache/") t))
     (setq sx-cache-directory               (var "sx/cache/"))
     (setq tldr-directory-path              (var "tldr/"))
+    (setq treemacs-persist-file            (var "treemacs-persist.org"))
     (setq undo-tree-history-directory-alist (list (cons "." (var "undo-tree-hist/"))))
     (setq user-emacs-ensime-directory      (var "ensime/"))
     (setq vimish-fold-dir                  (var "vimish-fold/"))


### PR DESCRIPTION
Treemacs is a tree layout file explorer for Emacs.
https://github.com/Alexander-Miller/treemacs

- This file is used to store Treemacs workspaces between sessions.
- The workspaces are saved in an org compatible format.