### PR TITLE
hackernews: theme hackernews-visited-links-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -288,6 +288,7 @@ directories."
     (eval-after-load 'geiser
       `(make-directory ,(var "geiser/") t))
     (setq geiser-repl-history-filename     (var "geiser/repl-history"))
+    (setq hackernews-visited-links-file    (var "hackernews/visited-links.el"))
     (eval-after-load 'helm
       `(make-directory ,(var "helm/") t))
     (setq helm-adaptive-history-file       (var "helm/adaptive-history.el"))


### PR DESCRIPTION
This file is used to store an s-expression.  This is the only data file of the package to date, but the package places the file in a subdirectory of its own by default, to accommodate future files.  This package takes care of creating the containing directory if necessary.

Homepage: https://github.com/clarete/hackernews.el