### PR TITLE
logview: theme logview-cache-filename and logview-views-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -314,6 +314,8 @@ directories."
     (eval-after-load 'lookup
       `(make-directory ,(etc "lookup/") t))
     (setq litable-list-file                (var "litable-list.el"))
+    (setq logview-cache-filename           (var "logview-cache"))
+    (setq logview-views-file               (etc "logview-views"))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq lsp-session-file                 (var "lsp-session.el"))
     (setq magithub-dir                     (var "magithub/"))


### PR DESCRIPTION
logview-cache-filename:
- This file is used to store cache data

logview-views-file:
- This file is used to store an s-expression.
- This file is used to store different views (/filters)

Repo link: https://github.com/doublep/logview