### PR TITLE
x86-lookup: theme x86-lookup-cache-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -378,6 +378,7 @@ directories."
     (setq wl-alias-file                    (etc "wanderlust/alias"))
     (setq wl-x-face-file                   (etc "wanderlust/x-face"))
     (setq wl-temporary-file-directory      (var "wanderlust-tmp"))
+    (setq x86-lookup-cache-directory       (var "x86-lookup/cache/"))
     (eval-after-load 'xkcd
       `(make-directory ,(var "xkcd/") t))
     (setq xkcd-cache-dir                   (var "xkcd/"))


### PR DESCRIPTION
This directory is used to store an s-expression file generated from
the PDF.  The generated file is named <sha1>_v3 in this directory.

The package will create the directory if it does not exist.

https://github.com/skeeto/x86-lookup