### PR TITLE
CIDER: theme cider-repl-history-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -267,6 +267,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq bookiez-file                     (var "bookiez"))
     (eval-after-load 'company
       `(make-directory ,(var "company/") t))
+    (setq cider-repl-history-file          (var "cider-repl-history.el"))
     (setq company-statistics-file          (var "company/statistics.el"))
     (setq company-tabnine-binaries-folder  (var "company/tabnine-binaries"))
     (setq dap--breakpoints-file            (var "dap-breakpoints"))


### PR DESCRIPTION
This file is used to store the CIDER REPL history. It stores s-expressions, and the content is similar to the following:

```
;; -*- coding: utf-8-unix -*-
;; Automatically written history of CIDER REPL session
;; Edit at your own risk

("(go)" "(halt)")
```
