### PR TITLE
lsp-mode: Theme lsp-server-install-dir

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -328,6 +328,7 @@ directories."
     (setq logview-views-file               (etc "logview-views"))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq lsp-python-ms-dir                (var "lsp-python-ms/"))
+    (setq lsp-server-install-dir           (var "lsp-mode/server/"))
     (setq lsp-session-file                 (var "lsp-session.el"))
     (setq lsp-java-workspace-dir           (var "lsp-java/workspace/"))
     (setq lsp-java-server-install-dir      (var "lsp-java/eclipse.jdt.ls/server/"))


### PR DESCRIPTION
Hello,

Since [lsp-mode](https://github.com/emacs-lsp/lsp-mode) now support automated installation of server executables, I have added this variable.

A question: `lsp-session-file` which is configured just below the added variable is for the same package. Should I change it to `lsp-mode/session.el` or keep it as it is?
