### PR TITLE
undo-fu-session: theme undo-fu-session-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -380,6 +380,7 @@ directories."
     (setq transient-values-file            (etc "transient/values.el"))
     (setq treemacs-persist-file            (var "treemacs/persist.org"))
     (setq treemacs-last-error-persist-file (var "treemacs/persist-last-error.org"))
+    (setq undo-fu-session-directory        (var "undo-fu-session/"))
     (setq undo-tree-history-directory-alist (list (cons "." (var "undo-tree-hist/"))))
     (setq user-emacs-ensime-directory      (var "ensime/"))
     (setq vimish-fold-dir                  (var "vimish-fold/"))


### PR DESCRIPTION
Package: [ideasman42/emacs-undo-fu-session](https://gitlab.com/ideasman42/emacs-undo-fu-session)

* This is the only configuration/data directory of the package.
* The files are used to store s-expressions.
* This package does take care of creating the directory if necessary.

Please ignore the previous PR, I messed up. I guess that's what I get for trying to use the GitHub web UI for a quick edit instead of using Magit...

