### PR TITLE
Fix omission from 79a7650 (create "lsp" directory)

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -329,6 +329,8 @@ directories."
       `(make-directory ,(etc "lookup/") t))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq lsp-python-ms-dir                (var "lsp-python-ms/"))
+    (eval-after-load 'lsp-mode
+      `(make-directory ,(var "lsp/") t))
     (setq lsp-server-install-dir           (var "lsp/server/"))
     (setq lsp-session-file                 (var "lsp/session.el"))
     (setq lsp-java-workspace-dir           (var "lsp-java/workspace/"))

--- a/no-littering.el
+++ b/no-littering.el
@@ -321,12 +321,12 @@ directories."
       `(make-directory ,(var "jabber/history/") t))
     (setq keyfreq-file                     (var "keyfreq.el"))
     (setq keyfreq-file-lock                (var "keyfreq.lock"))
-    (eval-after-load 'lookup
-      `(make-directory ,(etc "lookup/") t))
     (setq libbcel-oauth-store-filename     (var "libbcel-oauth-store.el.gpg"))
     (setq litable-list-file                (var "litable-list.el"))
     (setq logview-cache-filename           (var "logview-cache"))
     (setq logview-views-file               (etc "logview-views"))
+    (eval-after-load 'lookup
+      `(make-directory ,(etc "lookup/") t))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq lsp-python-ms-dir                (var "lsp-python-ms/"))
     (setq lsp-server-install-dir           (var "lsp/server/"))


### PR DESCRIPTION
The server subdirectory might have the same problem, but my usage does
not involve that one so I only encountered this one error and was too
lazy to test the other one as it seems to require 3rd party
executables.