### PR TITLE
eudc: theme eudc-options-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -214,6 +214,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq diary-file                       (var "diary"))
     (setq epkg-repository                  (var "epkgs/"))
     (setq eshell-directory-name            (var "eshell/"))
+    (setq eudc-options-file                (etc "eudc-options.el"))
     (eval-after-load 'eww
       `(make-directory ,(var "eww/") t))
     (setq eww-bookmarks-directory          (var "eww/"))


### PR DESCRIPTION
- This is the only configuration file of the package
- This file is loaded with eudc and sets config variables

Example of the file contents:
````elisp
;; This file was automatically generated by eudc.el.

(provide 'eudc-options-file)
(eudc-set-server "ldap://localhost:1389" 'ldap t)
(setq eudc-server-hotlist '(("ldap://localhost:1389" . ldap)))
````

Personally, I don't understand why eudc needs to save all these variables in a custom file and load it, in a way re-implementing the customize-interface. There is a function `eudc-edit-hotlist` that lets you edit the hotlist in a special buffer. But what’s the use? Why not just use a correct custom `:type`?
Maybe I should suggest these changes to eudc eventually.