### PR TITLE
filesets: theme filesets-menu-cache-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -218,6 +218,7 @@ This variable has to be set before `no-littering' is loaded.")
     (eval-after-load 'eww
       `(make-directory ,(var "eww/") t))
     (setq eww-bookmarks-directory          (var "eww/"))
+    (setq filesets-menu-cache-file         (var "filesets-menu-cache.el"))
     (setq gamegrid-user-score-file-directory (var "gamegrid-user-score/"))
     (setq ido-save-directory-list-file     (var "ido-save-directory-list.el"))
     (setq image-dired-db-file              (var "image-dired/db.el"))


### PR DESCRIPTION
- This file is used to store s-expressions
- This is a built-in feature