### PR TITLE
type-break: theme type-break-file-name

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -385,6 +385,7 @@ directories."
     (setq transient-values-file            (etc "transient/values.el"))
     (setq treemacs-persist-file            (var "treemacs/persist.org"))
     (setq treemacs-last-error-persist-file (var "treemacs/persist-last-error.org"))
+    (setq type-break-file-name             (var "type-break.el"))
     (setq undo-fu-session-directory        (var "undo-fu-session/"))
     (setq undo-tree-history-directory-alist (list (cons "." (var "undo-tree-hist/"))))
     (setq user-emacs-ensime-directory      (var "ensime/"))


### PR DESCRIPTION
- This file is used to store an s-expression. (Merely a list of integers, tho)
- Third-party package. https://www.emacswiki.org/emacs/TypeBreakMode