### PR TITLE
helm: theme helm-net-curl-log-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -317,6 +317,7 @@ directories."
     (setq helm-adaptive-history-file       (var "helm/adaptive-history.el"))
     (setq helm-backup-path                 (var "helm/backup/"))
     (setq helm-github-stars-cache-file     (var "helm/github-stars-cache.el"))
+    (setq helm-net-curl-log-file           (var "helm/helm-curl.log"))
     (setq historian-save-file              (var "historian-save.el"))
     (setq indium-workspace-file            (var "indium/workspaces.el"))
     (setq irfc-directory                   (var "irfc/"))


### PR DESCRIPTION
This var was recently added to log curl errors when
helm-net-prefer-curl is set to t.

See: https://github.com/emacs-helm/helm/commit/dee9e48fa76ad4a0d7b4ad1f6f3e7dd53e74d7cd
