### PR TITLE
calc: theme calc-settings-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -209,6 +209,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq auto-save-list-file-prefix       (var "auto-save/sessions/"))
     (setq backup-directory-alist           (list (cons "." (var "backup/"))))
     (setq bookmark-default-file            (var "bookmark-default.el"))
+    (setq calc-settings-file               (etc "calc-settings.el"))
     (eval-after-load 'desktop
       `(make-directory ,(var "desktop/") t))
     (setq desktop-dirname                  (var "desktop/"))


### PR DESCRIPTION
This is a built-in package. 

- The file is used to store s-expressions.
- This is the only configuration/data file of the package that I know of. It is the only one listed in the Customization buffer.
- The file is by default stored at the top level of the user Emacs directory.

Thank you.
