### PR TITLE
equake: theme equake-persistent-display-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -309,6 +309,7 @@ directories."
     (eval-after-load 'emojify
       `(make-directory ,(var "emojify/") t))
     (setq emojify-emojis-dir               (var "emojify/"))
+    (setq equake-persistent-display-file   (var "equake-persistent-display"))
     (setq forge-database-file              (var "forge/database.sqlite"))
     (setq forge-post-directory             (var "forge/posts/"))
     (setq geben-temporary-file-directory   (var "geben/"))


### PR DESCRIPTION
Equake[1]  needs to be able to figure out what display to open on. When the
display value is not set in the environment, this task is complicated.  So
as one possible fallback, every time a graphical frame is opened we store
its display value in `equake-persistent-display-file` as a potential cue to
a likely display when the current display value is
unset/inaccessible (i.e. fallback to last known good value).

   - This file is used to store raw text.
   - This is currently the only configuration/data file of the package.

[1] https://gitlab.com/emacsomancer/equake