### PR TITLE
persist: theme persist--directory-location

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -368,6 +368,7 @@ directories."
     (setq org-recent-headings-save-file    (var "org/recent-headings.el"))
     (setq pandoc-data-dir                  (etc "pandoc-mode/"))
     (setq pcache-directory                 (var "pcache/"))
+    (setq persist--directory-location      (var "persist/"))
     (setq persistent-scratch-save-file     (var "persistent-scratch.el"))
     (setq persp-save-dir                   (var "persp-mode/"))
     (eval-after-load 'projectile


### PR DESCRIPTION
- [persist.el](https://elpa.gnu.org/packages/persist.html) is a third party package providing variables which persist across sessions.
- persist--directory-location is the location of persist directory where the variables are stored.