### PR TITLE
abbrev: re-theme /var/abbrev.el to /etc/abbrev.el

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -204,7 +204,7 @@ This variable has to be set before `no-littering' is loaded.")
 
 ;;; Built-in packages
 
-    (setq abbrev-file-name                 (var "abbrev.el"))
+    (setq abbrev-file-name                 (etc "abbrev.el"))
     (setq auto-insert-directory            (etc "auto-insert/"))
     (setq auto-save-list-file-prefix       (var "auto-save/sessions/"))
     (setq backup-directory-alist           (list (cons "." (var "backup/"))))


### PR DESCRIPTION
abbrev.el stores abbrev tables defined by the user using
s-expressions. Users would typically be inclined to check them into
version control as they would with snippets.

https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/abbrev.el#n43

Related to #135.