### PR TITLE
eshell: theme eshell-aliases file separately from other eshell files

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -221,6 +221,9 @@ This variable has to be set before `no-littering' is loaded.")
       `(make-directory ,(var "erc/dcc/") t))
     (setq erc-dcc-get-default-directory    (var "erc/dcc/"))
     (setq erc-log-channels-directory       (var "erc/log-channels/"))
+    (eval-after-load 'eshell
+      `(make-directory ,(etc "eshell/") t))
+    (setq eshell-aliases-file              (etc "eshell/aliases"))
     (setq eshell-directory-name            (var "eshell/"))
     (setq eudc-options-file                (etc "eudc-options.el"))
     (eval-after-load 'eww


### PR DESCRIPTION
The aliases file stores user-defined aliases used in Eshell. Users
would typically be inclined to check them into version control as they
would with snippets.

The em-alias.el file normally resides inside of the directory
corresponding to eshell-directory-name, and does not assist in
generating an additional containing directory, so we must make that
directory ourselves.

https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/eshell/em-alias.el#n103

Related to #135.