### PR TITLE
elfeed-score: theme `elfeed-score-score-file'

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -308,6 +308,7 @@ This variable has to be set before `no-littering' is loaded.")
       `(make-directory ,(var "elfeed/") t))
     (setq elfeed-db-directory              (var "elfeed/db/"))
     (setq elfeed-enclosure-default-dir     (var "elfeed/enclosures/"))
+    (setq elfeed-score-score-file          (etc "elfeed/score/score.el"))
     (setq elpher-bookmarks-file            (var "elpher-bookmarks.el"))
     (eval-after-load 'x-win
       (let ((session-dir (var "emacs-session/")))


### PR DESCRIPTION
This file is used to store an s-expression.  This is the only
configuration/data file of the package.

Original package: https://github.com/sp1ff/elfeed-score/
