### PR TITLE
pdf-view-restore: theme `pdf-view-restore-filename'

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -382,6 +382,7 @@ directories."
     (setq org-registry-file                (var "org/registry.el"))
     (setq pandoc-data-dir                  (etc "pandoc-mode/"))
     (setq pcache-directory                 (var "pcache/"))
+    (setq pdf-view-restore-filename        (var "pdf-view-restore.el"))
     (setq persist--directory-location      (var "persist/"))
     (setq persistent-scratch-save-file     (var "persistent-scratch.el"))
     (setq persp-save-dir                   (var "persp-mode/"))


### PR DESCRIPTION
This file is used to store an s-expression.  This is the only
data file of the package.

Package homepage: https://github.com/007kevin/pdf-view-restore/