### PR TITLE
clarify that container defaults to `user-default-directory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ insight into what package might have created them.
 
 This package sets out to fix this by changing the values of path
 variables to put configuration files in `no-littering-etc-directory`
-(defaulting to `~/.emacs.d/etc/`) and persistent data files in
-`no-littering-var-directory` (defaulting to `~/.emacs.d/var/`), and
+(defaulting to "etc/" under `user-emacs-directory`, thus usually
+"~/.emacs.d/etc/") and persistent data files in
+`no-littering-var-directory` (defaulting to "var/" under
+`user-emacs-directory`, thus usually "~/.emacs.d/var/"), and
 by using descriptive file names and subdirectories when appropriate.
 This is similar to a color-theme; a "path-theme" if you will.
 

--- a/no-littering.el
+++ b/no-littering.el
@@ -36,8 +36,10 @@
 
 ;; This package sets out to fix this by changing the values of path
 ;; variables to put configuration files in `no-littering-etc-directory'
-;; (defaulting to "~/.emacs.d/etc/") and persistent data files in
-;; `no-littering-var-directory' (defaulting to "~/.emacs.d/var/"), and
+;; (defaulting to "etc/" under `user-emacs-directory', thus usually
+;; "~/.emacs.d/etc/") and persistent data files in
+;; `no-littering-var-directory' (defaulting to "var/" under
+;; `user-emacs-directory', thus usually "~/.emacs.d/var/"), and
 ;; by using descriptive file names and subdirectories when appropriate.
 ;; This is similar to a color-theme; a "path-theme" if you will.
 


### PR DESCRIPTION
When first reading the README, I thought extra configuration would be needed on Linux because of conflicting defaults — the default user directory here is `~/.config/emacs`, so `no-littering`'s defaults of `~/.emacs.d/var/` and `~/.emacs.d/etc/` would need adjustment. After looking at the code, however, I realized that `no-littering` already places `var` and `etc` under `user-default-directory`, whatever that is. This change aligns documentation with what code is already doing (at the cost of slightly heavier prose).

No commit prefix as not related to a package.