### PR TITLE
org-roam: theme org-roam-db-location

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -385,6 +385,7 @@ directories."
     (setq org-journal-cache-file           (var "org/journal-cache.el"))
     (setq org-recent-headings-save-file    (var "org/recent-headings.el"))
     (setq org-registry-file                (var "org/registry.el"))
+    (setq org-roam-db-location             (var "org/org-roam.db"))
     (setq package-quickstart-file          (var "package-quickstart.el"))
     (setq pandoc-data-dir                  (etc "pandoc-mode/"))
     (setq pcache-directory                 (var "pcache/"))


### PR DESCRIPTION
URL of the repository: https://github.com/org-roam/org-roam

- This file is used to store an SQLITE3 database.
- This is the only configuration/data file of the package (as far as I know).
- This package takes care of creating the containing directory if necessary (in `org-roam-db`).
