### PR TITLE
Fix rendering of ~ in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ insight into what package might have created them.
 This package sets out to fix this by changing the values of path
 variables to put configuration files in `no-littering-etc-directory`
 (defaulting to "etc/" under `user-emacs-directory`, thus usually
-"~/.emacs.d/etc/") and persistent data files in
-`no-littering-var-directory` (defaulting to "var/" under
-`user-emacs-directory`, thus usually "~/.emacs.d/var/"), and
+`"~/.emacs.d/etc/"`) and persistent data files in
+`no-littering-var-directory` (defaulting to `"var/"` under
+`user-emacs-directory`, thus usually `"~/.emacs.d/var/"`), and
 by using descriptive file names and subdirectories when appropriate.
 This is similar to a color-theme; a "path-theme" if you will.
 


### PR DESCRIPTION
Unquoted, `~` renders as strikeout, so the readme looks like this:

> (defaulting to "etc/" under `user-emacs-directory`, thus usually
> "~/.emacs.d/etc/") and persistent data files in
> `no-littering-var-directory` (defaulting to "var/" under
> `user-emacs-directory`, thus usually "~/.emacs.d/var/"), and

(I've read the conventions file, but I wasn't sure what template to follow given that this is not about a specific package)