### PR TITLE
lsp-eslint: theme lsp-eslint-library-choices-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -358,6 +358,7 @@ directories."
     (eval-after-load 'lookup
       `(make-directory ,(etc "lookup/") t))
     (setq lookup-init-directory            (etc "lookup/"))
+    (setq lsp-eslint-library-choices-file  (var "lsp/eslint-library-choices.el"))
     (setq lsp-python-ms-dir                (var "lsp-python-ms/"))
     (eval-after-load 'lsp-mode
       `(make-directory ,(var "lsp/") t))


### PR DESCRIPTION
URL of the repository: https://github.com/emacs-lsp/lsp-mode

- This file is used to store an s-expression
- There is another configuration option in this package to store a file: `lsp-eslint-unzipped-path`. Nevertheless, I didn't create an `"lsp/eslint/"` directory to store both because this variable has a default value of `(f-join lsp-server-install-dir "eslint/unzipped")`and `lsp-server-install-dir` is already configured by no-littering.
- This package takes care of creating the containing directory thanks to my PR: https://github.com/emacs-lsp/lsp-mode/pull/2559.