### PR TITLE
Theme url-history-file and url-cookie-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -270,6 +270,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq url-cache-directory              (var "url/cache/"))
     (setq url-configuration-directory      (var "url/configuration/"))
     (setq url-cookie-file                  (var "url/configuration/cookies.el"))
+    (setq url-history-file                 (var "url/configuration/history.el"))
 
 ;;; Third-party packages
 

--- a/no-littering.el
+++ b/no-littering.el
@@ -269,6 +269,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq type-break-file-name             (var "type-break.el"))
     (setq url-cache-directory              (var "url/cache/"))
     (setq url-configuration-directory      (var "url/configuration/"))
+    (setq url-cookie-file                  (var "url/configuration/cookies.el"))
 
 ;;; Third-party packages
 


### PR DESCRIPTION
Both files contain s-expressions, so we use extension `.el`.