### PR TITLE
url: Re-interpret the conventions

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -268,7 +268,9 @@ This variable has to be set before `no-littering' is loaded.")
     (setq tramp-persistency-file-name      (var "tramp/persistency.el"))
     (setq type-break-file-name             (var "type-break.el"))
     (setq url-cache-directory              (var "url/cache/"))
-    (setq url-configuration-directory      (var "url/configuration/"))
+    (setq url-configuration-directory      (var "url/"))
+    (setq url-cookie-file                  (var "url/cookies.el"))
+    (setq url-history-file                 (var "url/history.el"))
 
 ;;; Third-party packages
 


### PR DESCRIPTION
This is response to #158.  @leungbk, do you agree this makes more sense?

This package features four location variables.

The value of `url-configuration-directory` affects the values of the
other three variables.  For some reason only `url-cache-directory` is
set when it is being defined. `url-cookie-file` and `url-history-file`
are initialized to nil and set to proper values when the `url` package
is first used.  This is done in `url-do-setup`.

We have to theme `url-configuration-directory` because third-party
package may put other files in there.  We do however give up on
following the conventions that led us to use "url/configuration/"
as its value.

Instead we use just "url/", which means that the cache directory and
the two files can be placed inside that directory, while also using
paths that are based on the names of the respective variables.

(We already did that for `url-cache-directory`, but not the other two
which we did not theme explicitly until now.)

In other words we violate the conventions in the case of one variable
so that we can avoid violating the conventions for three variables.