### PR TITLE
multisession: theme multisession-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -246,6 +246,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq image-dired-temp-image-file      (var "image-dired/temp-image"))
     (setq image-dired-temp-rotate-image-file (var "image-dired/temp-rotate-image"))
     (setq kkc-init-file-name               (var "kkc-init.el"))
+    (setq multisession-directory           (var "multisession/"))
     (eval-after-load 'newsticker
       `(make-directory ,(var "newsticker/") t))
     (setq newsticker-cache-filename        (var "newsticker/cache.el"))


### PR DESCRIPTION
multisession is a builtin package since Emacs 29.1

The directory is used to store multisession variables. e.g., recently used emojis