### PR TITLE
rime: theme rime-user-data-dir

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -424,6 +424,7 @@ directories."
     (setq quack-dir                        (var "quack/"))
     (setq rfc-mode-directory               (var "rfc-mode/"))
     (setq request-storage-directory        (var "request/storage/"))
+    (setq rime-user-data-dir               (var "rime/"))
     (setq rmh-elfeed-org-files             (list (var "elfeed/rmh-elfeed.org")))
     (setq runner-init-file                 (var "runner-init.el"))
     (setq save-kill-file-name              (var "save-kill.el"))


### PR DESCRIPTION
Theme rime-user-data-dir.

emacs-rime is a package for CJK(chinese, japanese, korean) users to input their characters, and `rime-user-data-dir` stores the config files.

https://github.com/DogLooksGood/emacs-rime
https://github.com/DogLooksGood/emacs-rime/blob/5c2ade217134f6f20cd405447af20825e5b44513/rime.el#L356