### PR TITLE
svg-lib: theme svg-lib-icons-dir

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -440,6 +440,7 @@ directories."
     (setq sly-mrepl-history-file-name      (var "sly/mrepl-history"))
     (setq smex-save-file                   (var "smex-save.el"))
     (setq speed-type-gb-dir                (var "speed-type/"))
+    (setq svg-lib-icons-dir                (var "svg-lib/icons/"))
     (eval-after-load 'sx
       `(make-directory ,(var "sx/cache/") t))
     (setq sx-cache-directory               (var "sx/cache/"))


### PR DESCRIPTION
Theme svg-lib-icons-dir from svg-lib package.

Variable definition (https://github.com/rougier/svg-lib/blob/master/svg-lib.el#L133) :
```elisp
(defcustom svg-lib-icons-dir
  (expand-file-name (concat user-emacs-directory ".cache/svg-lib/"))
  "svg-lib icons directory."
  :group 'svg-lib
  :type 'directory)
```

