### PR TITLE
fontaine: theme fontaine-latest-state-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -349,6 +349,7 @@ directories."
     (setq emojify-emojis-dir               (var "emojify/"))
     (setq epkg-repository                  (var "epkgs/"))
     (setq equake-persistent-display-file   (var "equake-persistent-display"))
+    (setq fontaine-latest-state-file       (var "fontaine-latest-state.eld"))
     (setq forge-database-file              (var "forge/database.sqlite"))
     (setq forge-post-directory             (var "forge/posts/"))
     (setq geben-temporary-file-directory   (var "geben/"))


### PR DESCRIPTION
Fontaine sets font configurations using presets. This elisp-data file
contains a key to the alist `fontaine-presets`, to persist the current
font preset choice across sessions.

By default, it is set to `(locate-user-emacs-file
"fontaine-latest-state.eld")`, we are just moving the same filename to
`var`. It's the only file setting in the package.

Home page with manual: https://protesilaos.com/emacs/fontaine

Source repo: https://git.sr.ht/~protesilaos/fontaine

Please use a dedicated feature branch.  This is why:

     https://github.com/magit/magit/wiki/Dedicated-pull-request-branches

Please try to follow the conventions.

     https://github.com/tarsius/no-littering#conventions

In the past the majority of contributors have ignored at least some of the conventions.  Others did not fully understand them or had a good reason to depart from the conventions but did not explain why that is so. Unfortunately it is hard for me as the maintainer to tell whether a contributor did not invest enough time to get things right or just forgot to be explicit about their thought process. The result is that a pull request is actually more work for me than a simple "please theme PACKAGE from URL".

Going forward contributors are expected to follow the conventions more closely from the get-go and to be explicit about their thought process. Adding such statements to commit messages, would be helpful for example:

   - This file is used to store an s-expression.
   - This file is used to store raw text.
   - This is the only configuration/data file of the package.
   - This package does/doesn't take care of creating the containing
     directory if necessary. (If the package does not do it, then you
     should also fix that and submit an upstream pull request.)

Also please link to the repository of the package that your pull request is theming.

Thanks!
