### PR TITLE
autobookmarks: theme abm-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -296,6 +296,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq auto-package-update-last-update-day-path (var "auto-package-update-last-update-day"))
     (eval-after-load 'bbdb
       `(make-directory ,(var "bbdb/") t))
+    (setq abm-file                         (var "autobookmarks.el"))
     (setq bbdb-file                        (var "bbdb/bbdb.el"))
     (setq bbdb-vcard-directory             (var "bbdb/vcard/"))
     (setq bm-repository-file               (var "bm-repository.el"))


### PR DESCRIPTION
- The package name and prefix differ, so we're using the package name
  for the file.
- This file is used to store an s-expression.
- This is the only configuration/data file of the package.
- This package does create the containing directory in the latest
  version, but previously did not.