### PR TITLE
racket-mode: Theme racket-repl-history-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -431,6 +431,7 @@ directories."
     (setq purpose-layout-dirs              (list (etc "window-purpose/layouts/")))
     (setq pyim-dcache-directory            (var "pyim/dcache/"))
     (setq quack-dir                        (var "quack/"))
+    (setq racket-repl-history-directory    (var "racket-mode/repl-history/"))
     (setq rfc-mode-directory               (var "rfc-mode/"))
     (setq request-storage-directory        (var "request/storage/"))
     (setq rime-user-data-dir               (var "rime/"))


### PR DESCRIPTION
https://github.com/greghendershott/racket-mode/blob/ab8f953728a653bc6c53681c845a3a69133fdd4d/racket-repl.el#L1228-L1231

The package creates the directory if it doesn't exist.

This is the only configured directory in the package.