### PR TITLE
elfeed-org: theme rmh-elfeed-org-files (fix path)

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -435,7 +435,7 @@ directories."
     (setq rfc-mode-directory               (var "rfc-mode/"))
     (setq request-storage-directory        (var "request/storage/"))
     (setq rime-user-data-dir               (var "rime/"))
-    (setq rmh-elfeed-org-files             (list (var "elfeed/rmh-elfeed.org")))
+    (setq rmh-elfeed-org-files             (list (etc "elfeed/rmh-elfeed.org")))
     (setq runner-init-file                 (var "runner-init.el"))
     (setq save-kill-file-name              (var "save-kill.el"))
     (setq save-visited-files-location      (var "save-visited-files-location"))


### PR DESCRIPTION
The `rmh-elfeed-org-files` are the list of configuration files where [elfeed-org](https://github.com/remyhonig/elfeed-org) find feeds.