### PR TITLE
uptimes: theme uptimes-database

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -457,6 +457,7 @@ directories."
     (setq undo-fu-session-directory        (var "undo-fu-session/"))
     (setq undohist-directory               (var "undohist/"))
     (setq undo-tree-history-directory-alist (list (cons "." (var "undo-tree-hist/"))))
+    (setq uptimes-database                 (var "uptimes.el"))
     (setq user-emacs-ensime-directory      (var "ensime/"))
     (setq vimish-fold-dir                  (var "vimish-fold/"))
     (eval-after-load 'wl


### PR DESCRIPTION
repos: https://github.com/davep/uptimes.el

This file is used to store an s-expression.
This is the only configuration/data file of the package.
This package does/doesn't take care of creating the containing
directory if necessary.
