### PR TITLE
spell-fu: theme spell-fu-directory

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -445,6 +445,7 @@ directories."
     (setq sly-mrepl-history-file-name      (var "sly/mrepl-history"))
     (setq smex-save-file                   (var "smex-save.el"))
     (setq speed-type-gb-dir                (var "speed-type/"))
+    (setq spell-fu-directory               (var "spell-fu/"))
     (setq svg-lib-icons-dir                (var "svg-lib/icons/"))
     (eval-after-load 'sx
       `(make-directory ,(var "sx/cache/") t))


### PR DESCRIPTION
Themes https://codeberg.org/ideasman42/emacs-spell-fu

This appears to be the only path-related variable used by spell-fu,
and is used to store multiple files. The docstring says that it's "The
directory to store dictionary data."

The files seem to come in pairs, one .el.data containing an s-exp and
a .txt file containing one word per line. Each pair represents one
dictionary, including the user's personal dictionary.

The personal dictionary suggests that maybe this should be under etc,
but most of the contents seem to be cache. The upstream author doesn't
provide a way to separate them, so I decided to just go with the
majority and call it var.

The package does handle creating the directory as necessary.