### PR TITLE
harpoon: theme harpoon-cache-file

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -358,6 +358,7 @@ directories."
       `(make-directory ,(var "geiser/") t))
     (setq geiser-repl-history-filename     (var "geiser/repl-history"))
     (setq hackernews-visited-links-file    (var "hackernews/visited-links.el"))
+    (setq harpoon-cache-file               (var "harpoon/"))
     (eval-after-load 'helm
       `(make-directory ,(var "helm/") t))
     (setq helm-adaptive-history-file       (var "helm/adaptive-history.el"))


### PR DESCRIPTION
https://github.com/otavioschwanck/harpoon.el.git

This is actually a
directory (https://github.com/otavioschwanck/harpoon.el/blob/b08d4af6e4ab404c8a1031ff8cbfff49d5c8aec4/harpoon.el#L135-L136);
the actual file name (whose name is not configurable), relative to this directory, is "harpoon".

As a consequence of this naming, the cache file will end up having
path "[...]/var/harpoon".

This is the only data directory of the package.

The package creates this directory, as well as the "harpoon" file.