### PR TITLE
eshell: Theme `eshell-rc-script` separately from other Eshell files

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -232,6 +232,8 @@ This variable has to be set before `no-littering' is loaded.")
     (eval-after-load 'eshell
       `(make-directory ,(etc "eshell/") t))
     (setq eshell-aliases-file              (etc "eshell/aliases"))
+    (setq eshell-rc-script                 (etc "eshell/rc"))
+    (setq eshell-login-script              (etc "eshell/login"))
     (setq eshell-directory-name            (var "eshell/"))
     (setq eudc-options-file                (etc "eudc-options.el"))
     (eval-after-load 'eww


### PR DESCRIPTION
This sets `eshell-rc-script` and `eshell-login-script`.  These script files are
the Eshell startup file, and do not contain data.  Instead, they contain a
series of Eshell commands, similar to `.bashrc`.

The moving of these files from `var` to `etc` follows the same reasoning used in
#138 for moving the Eshell aliases file.

The current configured values of these variables are `var/eshell/profile` and
`var/eshell/login`.  Following the conventions, they are changed to
`etc/eshell/rc` and `etc/eshell/login`, given that the suffix "-script" is
similar to a suffix "-file".