### PR TITLE
lsp-ltex: theme lsp-ltex-user-rules-path

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -387,6 +387,7 @@ directories."
       `(make-directory ,(etc "lookup/") t))
     (setq lookup-init-directory            (etc "lookup/"))
     (setq lsp-clojure-workspace-dir        (var "lsp-clojure/workspace/"))
+    (setq lsp-ltex-user-rules-path         (var "lsp-ltex/"))
     (setq lsp-eslint-library-choices-file  (var "lsp/eslint-library-choices.el"))
     (setq lsp-python-ms-dir                (var "lsp-python-ms/"))
     (eval-after-load 'lsp-mode


### PR DESCRIPTION
This is the path to a directory containing a single file named `stored-dictionary`, which contains the dictionary for the `lsp-ltex` emacs client for the ltex LanguageTool language-server, see https://github.com/emacs-languagetool/lsp-ltex.

The contained `stored-dictionary` file is stored in s-expression format.

This package asks the user via a prompt if it should create that directory when the use interactively adds a word to the ltex dictionary for the first time.

This is the only configuration/data file of the package, except `lsp-ltex-server-store-path`, but this is already correctly in `var` as it's by default set under the themed `lsp-server-install-dir`.