### PR TITLE
gnus-notes: Theme gnus-notes-top-dir

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -361,6 +361,8 @@ directories."
     (eval-after-load 'geiser
       `(make-directory ,(var "geiser/") t))
     (setq geiser-repl-history-filename     (var "geiser/repl-history"))
+    (setq gnus-notes-top-dir               (var "gnus-notes/"))
+    (setq gnus-notes-file                  (var "gnus-notes/articles.el"))
     (setq hackernews-visited-links-file    (var "hackernews/visited-links.el"))
     (setq harpoon-cache-file               (var "harpoon/"))
     (eval-after-load 'helm


### PR DESCRIPTION
Theme gnus-notes-top-dir', it is used to story any data that the
package writes.

The data is either /articles/ an S-expression or /crumbs/ a folder
that contains S-expressions.

The package takes care of creating it's directory.

- Repo-link: https://github.com/deusmax/gnus-notes