### PR TITLE
gnus: Theme gnus-startup-file so newsrc.eld is themed

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -243,8 +243,12 @@ This variable has to be set before `no-littering' is loaded.")
     (setq gamegrid-user-score-file-directory (var "gamegrid-user-score/"))
     (eval-after-load 'gnus
       `(make-directory ,(var "gnus/dribble/") t))
+    (eval-after-load 'gnus
+      `(make-directory ,(etc "gnus/") t))
     (setq gnus-dribble-directory           (var "gnus/dribble/"))
     (setq gnus-init-file                   (etc "gnus/init.el"))
+    ;;; Gnus hardcodes newsrc.eld to be based on gnus-startup-file' :/
+    (setq gnus-startup-file                (etc "gnus/newsrc"))
     (setq ido-save-directory-list-file     (var "ido-save-directory-list.el"))
     (setq image-dired-db-file              (var "image-dired/db.el"))
     (setq image-dired-dir                  (var "image-dired/"))


### PR DESCRIPTION
- Theme gnus-startup-file' it was suggested that this variable
  shouldn't be themed however gnus own configuration `newsrc.eld` is
  based on `(concat gnus-startup-file ".eld")` whichm means themeing
  is the only way to theme `newsrc.eld`.

- There are no downsides on this except that gnus won't read other
  readers newsrc anymore which is suggested anyway.

Fixes: dcc96cbf5f018a91d406926d3b69715847ef665a
Re: #142