### PR TITLE
elfeed-autoag: Theme elfeed-autotag-files

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -342,6 +342,7 @@ This variable has to be set before `no-littering' is loaded.")
     (setq elfeed-db-directory              (var "elfeed/db/"))
     (setq elfeed-enclosure-default-dir     (var "elfeed/enclosures/"))
     (setq elfeed-score-score-file          (etc "elfeed/score/score.el"))
+    (setq elfeed-autotag-files             (list (etc "elfeed/autotags.org")))
     (setq elpher-bookmarks-file            (var "elpher-bookmarks.el"))
     (eval-after-load 'x-win
       (let ((session-dir (var "emacs-session/")))


### PR DESCRIPTION
- elfeed-autotag-files :: the files is used to tag elfeed entries
    based on their properties similar to  elfeed-org but with defining feeds.
    The files contain the only configuration/data file of the package.
- The directory for the files that the package uses is already created
  for another package.

Repo-link: https://github.com/paulelms/elfeed-autotag