### PR TITLE
Improve migrate.org and mention it in the README

### DIFF
--- a/README.org
+++ b/README.org
@@ -24,9 +24,10 @@ this package depends on user contributions to accomplish decent
 coverage.  Pull requests are highly welcome (but please follow the
 conventions described below and in the pull request template).
 
-~no-littering~ cannot help with moving existing files to the new
-location.  You will have to move the files manually.  See issue
-[[https://github.com/emacscollective/no-littering/issues/79][#79]] for more information.
+This package does not automatically migrate existing files to their
+new locations, but unless you want to, you also do not have to do
+it completely by hand.  The contributed [[./migrate.org][migrate.org]] provides some
+guidance and tools to help with the migration.
 
 ** Usage
 

--- a/migrate.org
+++ b/migrate.org
@@ -61,7 +61,7 @@ and press =C-c C-c=.
 
 The result is a list of =progn= forms which can be evaluated by placing
 the point at the end of the =progn= form and calling =M-x eval-last-sexp=
-(sometimes bound to ~C-x C-e~).
+(usually bound to ~C-x C-e~).
 
 The form looks like this:
 
@@ -84,10 +84,9 @@ If you are satisfied, execute it and move to the next one.
 Some of the forms might error out when the source file does not exist.
 In that case there's nothing to do and you can move to the next one.
 
-Occasionally, the code generate is not valid and you need to do the
-migration manually.  For now, the only value which wasn't readily
-supported is =backup-directory-alist= which is not a string but an
-alist.
+Occasionally, the generated code is not valid and you need to do the
+migration manually.  For now, the only value which isn't supported is
+=backup-directory-alist= which is not a string but an alist.
 
 ** Remove customized values
 
@@ -97,7 +96,7 @@ by =no-littering=.  Simply run the following to remove all
 customizations.
 
 *Make sure to backup your custom file before running this so you can
-compare he results.*
+compare the results.*
 
 #+begin_src elisp
   (no-littering-custom-reset)

--- a/migrate.org
+++ b/migrate.org
@@ -52,7 +52,7 @@ We now have the old list and a new list and we can compare the
 existing values to new values.  The script below generates a migration
 script which you have to review and execute manually.
 
-#+begin_src elisp :wrap src elisp :results value
+#+begin_src elisp :wrap src elisp :results value pp
   (no-littering-generate-migration no-littering-current-values
 				   no-littering-new-values)
 #+end_src

--- a/migrate.org
+++ b/migrate.org
@@ -85,8 +85,7 @@ Some of the forms might error out when the source file does not exist.
 In that case there's nothing to do and you can move to the next one.
 
 Occasionally, the generated code is not valid and you need to do the
-migration manually.  For now, the only value which isn't supported is
-=backup-directory-alist= which is not a string but an alist.
+migration manually.
 
 ** Remove customized values
 

--- a/migrate.org
+++ b/migrate.org
@@ -49,8 +49,10 @@ Now we save the new themed values set by no-littering.
 ** Generate migrations
 
 We now have the old list and a new list and we can compare the
-existing values to new values.  The script below generates a migration
+existing values to new values.  The code below generates a migration
 script which you have to review and execute manually.
+In order to generate the script, place the cursor inside the code block
+and press =C-c C-c=.
 
 #+begin_src elisp :wrap src elisp :results value pp
   (no-littering-generate-migration no-littering-current-values

--- a/no-littering.el
+++ b/no-littering.el
@@ -51,9 +51,10 @@
 ;; coverage.  Pull requests are highly welcome (but please follow the
 ;; conventions described below and in the pull request template).
 
-;; `no-littering' cannot help with moving existing files to the new
-;; location.  You will have to move the files manually.  See issue
-;; #79 for more information.
+;; This package does not automatically migrate existing files to their
+;; new locations, but unless you want to, you also do not have to do
+;; it completely by hand.  The contributed "migrate.org" provides some
+;; guidance and tools to help with the migration.
 
 ;;;; Usage
 


### PR DESCRIPTION
I was surprised to see that the README stated that no-littering could not help the user migrate their files while, actually, there was a handy migration guide in the repository. Moreover, some steps in the guide seemed unclear to me. This PR thus:

* Mentions the `migrate.org` file in the README and in the comments at the top of `no-litter.el`.
* Improves the way the results of the Elisp Babel block containing the migration script generator are printed in the org file.
* Improves the wording and the spelling in that same file.