### PR TITLE
gitignore: Exclude *-pkg.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /*.elc
 /*-autoloads.el
+/*-pkg.el
 /.config.mk
 
 /docs/*.html


### PR DESCRIPTION
Exclude "*-pkg.el" files. These are generated by the `:vc' keyword from use-package.