### PR TITLE
Backquote eshell config

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -190,7 +190,7 @@ This variable has to be set before `no-littering' is loaded.")
 
     (eval-after-load 'desktop     '(make-directory desktop-dirname t))
     (eval-after-load 'erc         '(make-directory erc-dcc-get-default-directory t))
-    (eval-after-load 'eshell      '(with-file-modes #o700
+    (eval-after-load 'eshell      `(with-file-modes #o700
                                      (make-directory ,(etc "eshell/") t)))
     (eval-after-load 'eww         '(make-directory eww-bookmarks-directory t))
     (eval-after-load 'gnus        `(make-directory ,(etc "gnus/") t))


### PR DESCRIPTION
Otherwise, ",(etc" won't get eagerly expanded and will error at runtime.