### PR TITLE
treesit: Guard treesit-auto-install-grammar with boundp

### DIFF
--- a/no-littering.el
+++ b/no-littering.el
@@ -211,7 +211,7 @@ This variable has to be set before `no-littering' is loaded.")
            ;; The directory must exist.  Keep a value of `always' -- only
            ;; `ask' always installs in "user-emacs-directory/tree-sitter".
            ;; See https://debbugs.gnu.org/cgi/bugreport.cgi?bug=79862.
-           (when (and (not (version< emacs-version "30.0.90"))
+           (when (and (boundp 'treesit-auto-install-grammar)
                       (eq treesit-auto-install-grammar 'ask))
              (make-directory dir t)
              (setq treesit-auto-install-grammar 'ask-dir)))))


### PR DESCRIPTION
`treesit-auto-install-grammar` (and its `ask-dir` value) only exist on Emacs 31 — the defcustom in lisp/treesit.el is tagged `:version "31.1"`. The version guard added in 4740025 lets Emacs 30 through, so loading no-littering on Emacs 30.x with tree-sitter support signals `(void-variable treesit-auto-install-grammar)` as soon as `treesit` is loaded, which in a typical init takes down everything configured after no-littering.

Guard on the variable itself instead. Verified on Emacs 30.2: the reproduction in #276 loads cleanly with this patch, and the file byte-compiles without warnings.

Fixes #276.